### PR TITLE
Set fixed height and width for icon

### DIFF
--- a/ui/components/layout/Footer.tsx
+++ b/ui/components/layout/Footer.tsx
@@ -6,7 +6,7 @@ const Footer: React.FC = () => {
 
   return (
     <footer>
-      <FontAwesomeIcon icon={faCopyright} />
+      <FontAwesomeIcon icon={faCopyright} style={{ width: "18px", height: "18px" }} />
       <p> {currentYear} Ivan Wong. All Rights Reserved.</p>
     </footer>
   );

--- a/ui/features/gallery/Lightbox.tsx
+++ b/ui/features/gallery/Lightbox.tsx
@@ -23,7 +23,7 @@ const Lightbox = ({ selectedImage, onClose }: LightboxProps) => {
           draggable={false}
         />
         <button className="gallery-lightbox__close" onClick={onClose}>
-          <FontAwesomeIcon icon={faX} size="lg" />
+          <FontAwesomeIcon icon={faX} style={{ width: "20px", height: "20px" }} />
         </button>
       </div>
     </div>


### PR DESCRIPTION
Set a fixed height and width for the icon to prevent it from initially rendering large size before resizing to a smaller size.